### PR TITLE
BioApi Image migrated to alpine 3.18

### DIFF
--- a/.github/workflows/master-pr-wf.yaml
+++ b/.github/workflows/master-pr-wf.yaml
@@ -20,8 +20,15 @@ jobs:
           git tag ${{ env.VERSION }}
           if [ $? -ne 0 ]
           then
-            core.setFailed('This bio-api version tag already exists in repository')
+            echo "TAG_EXISTS=1" >> $GITHUB_ENV
+            
           fi
+      - name: bio-api current version tag exists?
+        if: ${{ env.TAG_EXISTS }} == 1
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('This bio-api version tag already exists in repository')          
 
   version-check-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/master-pr-wf.yaml
+++ b/.github/workflows/master-pr-wf.yaml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get version
-        run: BASEDIR=$(pwd) ./tools/get_version.sh
+        run: BASEDIR=$(pwd)/bio-api/bioapi.py ./tools/get_version.sh
       - name: Set version
-        run: BASEDIR=$(pwd) ./tools/get_version.sh >> $GITHUB_ENV
+        run: BASEDIR=$(pwd)/bio-api/bioapi.py ./tools/get_version.sh >> $GITHUB_ENV
       - name: Check if tag exist.
         shell: bash
         run: |

--- a/.github/workflows/master-pr-wf.yaml
+++ b/.github/workflows/master-pr-wf.yaml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get version
-        run: BASEDIR=$(pwd)/bio-api/bioapi.py ./tools/get_version.sh
+        run: SETTINGSFILE=$(pwd)/bio-api/bioapi.py ./tools/get_version.sh
       - name: Set version
-        run: BASEDIR=$(pwd)/bio-api/bioapi.py ./tools/get_version.sh >> $GITHUB_ENV
+        run: SETTINGSFILE=$(pwd)/bio-api/bioapi.py ./tools/get_version.sh >> $GITHUB_ENV
       - name: Check if tag exist.
         shell: bash
         run: |

--- a/.github/workflows/master-pr-wf.yaml
+++ b/.github/workflows/master-pr-wf.yaml
@@ -5,7 +5,25 @@ on:
       - "main"
       - "master"
 jobs:
-  version-check:
+  version-check-repo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get version
+        run: BASEDIR=$(pwd) ./tools/get_version.sh
+      - name: Set version
+        run: BASEDIR=$(pwd) ./tools/get_version.sh >> $GITHUB_ENV
+      - name: Check if tag exist.
+        shell: bash
+        run: |
+          git tag ${{ env.VERSION }}
+          if [ $? -ne 0 ]
+          then
+            core.setFailed('This bio-api version tag already exists in repository')
+          fi
+
+  version-check-docker:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/master-pr-wf.yaml
+++ b/.github/workflows/master-pr-wf.yaml
@@ -21,10 +21,9 @@ jobs:
           if [ $? -ne 0 ]
           then
             echo "TAG_EXISTS=1" >> $GITHUB_ENV
-            
           fi
       - name: bio-api current version tag exists?
-        if: ${{ env.TAG_EXISTS }} == 1
+        if: env.TAG_EXISTS == 1
         uses: actions/github-script@v3
         with:
           script: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.8
+FROM python:3.10-alpine3.18
 ENV MONGO_HOST "mongo"
 ENV MONGO_PORT 27017
 ENV MONGO_USER "bioapi"

--- a/bio-api/bioapi.py
+++ b/bio-api/bioapi.py
@@ -19,7 +19,7 @@ IS_DEBUG: bool = os.environ.get('DEBUG', 'true') == 'true'
 PROCESS_POOL_WORKERS: int = int(os.getenv('PROCESS_POOL_WORKERS', 4))
 
 # BioAPI version
-VERSION = '1.0.3'
+VERSION = '1.0.4'
 
 # Valid pathways sources
 PATHWAYS_SOURCES = ["kegg", "biocarta", "ehmn", "humancyc", "inoh", "netpath", "pid", "reactome",


### PR DESCRIPTION
- Image build will use alpine 3.18 now.
- Master PR WF now will check for repo tags.
- Version bumped up to 1.0.4